### PR TITLE
fix: the crux api key is transmitted as a url query ... in crux.js

### DIFF
--- a/lib/crux.js
+++ b/lib/crux.js
@@ -123,9 +123,9 @@ async function postJson(endpoint, apiKey, body) {
 	for (let attempt = 0; ; attempt++) {
 		await pace();
 
-		const res = await fetch(`${endpoint}?key=${encodeURIComponent(apiKey)}`, {
+		const res = await fetch(endpoint, {
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: { "Content-Type": "application/json", "X-Goog-Api-Key": apiKey },
 			body: JSON.stringify(body),
 		});
 


### PR DESCRIPTION
## Summary
Fix high severity security issue in `lib/crux.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `lib/crux.js:126` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 2-step |

**Description**: The CrUX API key is transmitted as a URL query parameter rather than using HTTP Authorization headers. This exposes the API key in server logs, proxy logs, browser history, and network monitoring tools. Any party with access to these logging systems can extract the key and use it for unauthorized API calls.

## Evidence

**Exploitation scenario**: An attacker with read access to server logs, proxy logs, or network traffic captures can extract the API key from logged URLs.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `lib/crux.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
